### PR TITLE
Provide a match-like interface for destructuring the data

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,50 +1,50 @@
-import { Failure, fold, Initialized, Kinds, Pending, Success } from "./index";
+import { Failure, fold, Initialized, Kinds, Pending, Success } from './index';
 
-test("Kinds", () => {
+test('Kinds', () => {
   expect(Kinds).toEqual({
-    Failure: "Failure",
-    Initialized: "Initialized",
-    Pending: "Pending",
-    Success: "Success",
-    _: "_"
+    Failure: 'Failure',
+    Initialized: 'Initialized',
+    Pending: 'Pending',
+    Success: 'Success',
+    _: '_'
   });
 });
 
-test("Initialized", () => {
+test('Initialized', () => {
   expect(new Initialized()).toBeInstanceOf(Initialized);
-  expect(new Initialized().kind).toEqual("Initialized");
+  expect(new Initialized().kind).toEqual('Initialized');
 });
 
-test("Pending", () => {
+test('Pending', () => {
   expect(new Pending()).toBeInstanceOf(Pending);
-  expect(new Pending().kind).toEqual("Pending");
+  expect(new Pending().kind).toEqual('Pending');
 });
 
-test("Success", () => {
-  const data = { apple: "sauce" };
+test('Success', () => {
+  const data = { apple: 'sauce' };
   const state = new Success(data);
   expect(state).toBeInstanceOf(Success);
-  expect(state.kind).toEqual("Success");
+  expect(state.kind).toEqual('Success');
   expect(state.data).toEqual(data);
 });
 
-test("Success without data", () => {
+test('Success without data', () => {
   expect(() => new Success()).toThrowError('Parameter "data" is required');
 });
 
-test("Failure", () => {
+test('Failure', () => {
   const error = 500;
   const state = new Failure(error);
   expect(state).toBeInstanceOf(Failure);
-  expect(state.kind).toEqual("Failure");
+  expect(state.kind).toEqual('Failure');
   expect(state.error).toEqual(error);
 });
 
-test("Failure without error", () => {
+test('Failure without error', () => {
   expect(() => new Failure()).toThrowError('Parameter "error" is required');
 });
 
-test("fold initialized", () => {
+test('fold initialized', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
@@ -59,7 +59,7 @@ test("fold initialized", () => {
   expect(failureMock).not.toHaveBeenCalled();
 });
 
-test("fold pending", () => {
+test('fold pending', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
@@ -74,14 +74,14 @@ test("fold pending", () => {
   expect(failureMock).not.toHaveBeenCalled();
 });
 
-test("fold success", () => {
+test('fold success', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
   const failureMock = jest.fn();
   const view = fold(initializedMock, pendingMock, failureMock, successMock);
 
-  const data = { apple: "sauce" };
+  const data = { apple: 'sauce' };
   view(new Success(data));
   expect(initializedMock).not.toHaveBeenCalled();
   expect(pendingMock).not.toHaveBeenCalled();
@@ -90,7 +90,7 @@ test("fold success", () => {
   expect(failureMock).not.toHaveBeenCalled();
 });
 
-test("fold failure", () => {
+test('fold failure', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
@@ -106,7 +106,7 @@ test("fold failure", () => {
   expect(failureMock).toHaveBeenCalledWith(error);
 });
 
-test("fold unknown", () => {
+test('fold unknown', () => {
   const otherMock = jest.fn();
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
@@ -114,10 +114,10 @@ test("fold unknown", () => {
   const failureMock = jest.fn();
   const view = fold(initializedMock, pendingMock, failureMock, successMock);
 
-  expect(() => view(otherMock)).toThrowError("Unknown RemoteData state:");
+  expect(() => view(otherMock)).toThrowError('Unknown RemoteData state:');
 });
 
-test("match initialized", () => {
+test('match initialized', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
@@ -139,7 +139,7 @@ test("match initialized", () => {
   expect(_Mock).not.toHaveBeenCalled();
 });
 
-test("match pending", () => {
+test('match pending', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
@@ -161,14 +161,14 @@ test("match pending", () => {
   expect(_Mock).not.toHaveBeenCalled();
 });
 
-test("match success", () => {
+test('match success', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
   const failureMock = jest.fn();
   const _Mock = jest.fn();
 
-  const data = { apple: "sauce" };
+  const data = { apple: 'sauce' };
   new Success(data).match({
     Initialized: initializedMock,
     Pending: pendingMock,
@@ -184,7 +184,7 @@ test("match success", () => {
   expect(_Mock).not.toHaveBeenCalled();
 });
 
-test("match failure", () => {
+test('match failure', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
@@ -207,7 +207,7 @@ test("match failure", () => {
   expect(_Mock).not.toHaveBeenCalled();
 });
 
-test("match _ with Initialized", () => {
+test('match _ with Initialized', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
@@ -235,7 +235,7 @@ test("match _ with Initialized", () => {
   expect(_Mock).toHaveBeenCalledTimes(1);
 });
 
-test("match _ with Pending", () => {
+test('match _ with Pending', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
@@ -263,14 +263,14 @@ test("match _ with Pending", () => {
   expect(_Mock).toHaveBeenCalledTimes(1);
 });
 
-test("match _ with Success", () => {
+test('match _ with Success', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
   const failureMock = jest.fn();
   const _Mock = jest.fn();
 
-  const data = { apple: "sauce" };
+  const data = { apple: 'sauce' };
   new Success(data).match({
     _: _Mock
   });
@@ -294,7 +294,7 @@ test("match _ with Success", () => {
   expect(_Mock).toHaveBeenCalledTimes(1);
 });
 
-test("match _ with Failure", () => {
+test('match _ with Failure', () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,59 +1,55 @@
-import { Failure, fold, Initialized, Kinds, Pending, Success } from './index';
+import { Failure, fold, Initialized, Kinds, Pending, Success } from "./index";
 
-test('Kinds', () => {
+test("Kinds", () => {
   expect(Kinds).toEqual({
-    'Failure': 'Failure',
-    'Initialized': 'Initialized',
-    'Pending': 'Pending',
-    'Success': 'Success'
+    Failure: "Failure",
+    Initialized: "Initialized",
+    Pending: "Pending",
+    Success: "Success",
+    _: "_"
   });
 });
 
-test('Initialized', () => {
+test("Initialized", () => {
   expect(new Initialized()).toBeInstanceOf(Initialized);
-  expect(new Initialized().kind).toEqual('Initialized');
+  expect(new Initialized().kind).toEqual("Initialized");
 });
 
-test('Pending', () => {
+test("Pending", () => {
   expect(new Pending()).toBeInstanceOf(Pending);
-  expect(new Pending().kind).toEqual('Pending');
+  expect(new Pending().kind).toEqual("Pending");
 });
 
-test('Success', () => {
-  const data = { apple: 'sauce' };
+test("Success", () => {
+  const data = { apple: "sauce" };
   const state = new Success(data);
   expect(state).toBeInstanceOf(Success);
-  expect(state.kind).toEqual('Success');
+  expect(state.kind).toEqual("Success");
   expect(state.data).toEqual(data);
 });
 
-test('Success without data', () => {
+test("Success without data", () => {
   expect(() => new Success()).toThrowError('Parameter "data" is required');
 });
 
-test('Failure', () => {
+test("Failure", () => {
   const error = 500;
   const state = new Failure(error);
   expect(state).toBeInstanceOf(Failure);
-  expect(state.kind).toEqual('Failure');
+  expect(state.kind).toEqual("Failure");
   expect(state.error).toEqual(error);
 });
 
-test('Failure without error', () => {
+test("Failure without error", () => {
   expect(() => new Failure()).toThrowError('Parameter "error" is required');
 });
 
-test('fold initialized', () => {
+test("fold initialized", () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
   const failureMock = jest.fn();
-  const view = fold(
-    initializedMock,
-    pendingMock,
-    failureMock,
-    successMock,
-  );
+  const view = fold(initializedMock, pendingMock, failureMock, successMock);
 
   view(new Initialized());
   expect(initializedMock).toHaveBeenCalledTimes(1);
@@ -63,17 +59,12 @@ test('fold initialized', () => {
   expect(failureMock).not.toHaveBeenCalled();
 });
 
-test('fold pending', () => {
+test("fold pending", () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
   const failureMock = jest.fn();
-  const view = fold(
-    initializedMock,
-    pendingMock,
-    failureMock,
-    successMock,
-  );
+  const view = fold(initializedMock, pendingMock, failureMock, successMock);
 
   view(new Pending());
   expect(initializedMock).not.toHaveBeenCalled();
@@ -83,19 +74,14 @@ test('fold pending', () => {
   expect(failureMock).not.toHaveBeenCalled();
 });
 
-test('fold success', () => {
+test("fold success", () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
   const failureMock = jest.fn();
-  const view = fold(
-    initializedMock,
-    pendingMock,
-    failureMock,
-    successMock,
-  );
+  const view = fold(initializedMock, pendingMock, failureMock, successMock);
 
-  const data = { apple: 'sauce' };
+  const data = { apple: "sauce" };
   view(new Success(data));
   expect(initializedMock).not.toHaveBeenCalled();
   expect(pendingMock).not.toHaveBeenCalled();
@@ -104,17 +90,12 @@ test('fold success', () => {
   expect(failureMock).not.toHaveBeenCalled();
 });
 
-test('fold failure', () => {
+test("fold failure", () => {
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
   const failureMock = jest.fn();
-  const view = fold(
-    initializedMock,
-    pendingMock,
-    failureMock,
-    successMock,
-  );
+  const view = fold(initializedMock, pendingMock, failureMock, successMock);
 
   const error = 500;
   view(new Failure(error));
@@ -125,18 +106,221 @@ test('fold failure', () => {
   expect(failureMock).toHaveBeenCalledWith(error);
 });
 
-test('fold unknown', () => {
+test("fold unknown", () => {
   const otherMock = jest.fn();
   const initializedMock = jest.fn();
   const pendingMock = jest.fn();
   const successMock = jest.fn();
   const failureMock = jest.fn();
-  const view = fold(
-    initializedMock,
-    pendingMock,
-    failureMock,
-    successMock,
-  );
+  const view = fold(initializedMock, pendingMock, failureMock, successMock);
 
-  expect(() => view(otherMock)).toThrowError('Unknown RemoteData state:');
+  expect(() => view(otherMock)).toThrowError("Unknown RemoteData state:");
+});
+
+test("match initialized", () => {
+  const initializedMock = jest.fn();
+  const pendingMock = jest.fn();
+  const successMock = jest.fn();
+  const failureMock = jest.fn();
+  const _Mock = jest.fn();
+
+  new Initialized().match({
+    Initialized: initializedMock,
+    Pending: pendingMock,
+    Success: successMock,
+    Failure: failureMock,
+    _: _Mock
+  });
+  expect(initializedMock).toHaveBeenCalledTimes(1);
+  expect(initializedMock).toHaveBeenCalledWith();
+  expect(pendingMock).not.toHaveBeenCalled();
+  expect(successMock).not.toHaveBeenCalled();
+  expect(failureMock).not.toHaveBeenCalled();
+  expect(_Mock).not.toHaveBeenCalled();
+});
+
+test("match pending", () => {
+  const initializedMock = jest.fn();
+  const pendingMock = jest.fn();
+  const successMock = jest.fn();
+  const failureMock = jest.fn();
+  const _Mock = jest.fn();
+
+  new Pending().match({
+    Initialized: initializedMock,
+    Pending: pendingMock,
+    Success: successMock,
+    Failure: failureMock,
+    _: _Mock
+  });
+  expect(initializedMock).not.toHaveBeenCalled();
+  expect(pendingMock).toHaveBeenCalledTimes(1);
+  expect(pendingMock).toHaveBeenCalledWith();
+  expect(successMock).not.toHaveBeenCalled();
+  expect(failureMock).not.toHaveBeenCalled();
+  expect(_Mock).not.toHaveBeenCalled();
+});
+
+test("match success", () => {
+  const initializedMock = jest.fn();
+  const pendingMock = jest.fn();
+  const successMock = jest.fn();
+  const failureMock = jest.fn();
+  const _Mock = jest.fn();
+
+  const data = { apple: "sauce" };
+  new Success(data).match({
+    Initialized: initializedMock,
+    Pending: pendingMock,
+    Success: successMock,
+    Failure: failureMock,
+    _: _Mock
+  });
+  expect(initializedMock).not.toHaveBeenCalled();
+  expect(pendingMock).not.toHaveBeenCalled();
+  expect(successMock).toHaveBeenCalledTimes(1);
+  expect(successMock).toHaveBeenCalledWith(data);
+  expect(failureMock).not.toHaveBeenCalled();
+  expect(_Mock).not.toHaveBeenCalled();
+});
+
+test("match failure", () => {
+  const initializedMock = jest.fn();
+  const pendingMock = jest.fn();
+  const successMock = jest.fn();
+  const failureMock = jest.fn();
+  const _Mock = jest.fn();
+
+  const error = 500;
+  new Failure(error).match({
+    Initialized: initializedMock,
+    Pending: pendingMock,
+    Success: successMock,
+    Failure: failureMock,
+    _: _Mock
+  });
+  expect(initializedMock).not.toHaveBeenCalled();
+  expect(pendingMock).not.toHaveBeenCalled();
+  expect(successMock).not.toHaveBeenCalled();
+  expect(failureMock).toHaveBeenCalledTimes(1);
+  expect(failureMock).toHaveBeenCalledWith(error);
+  expect(_Mock).not.toHaveBeenCalled();
+});
+
+test("match _ with Initialized", () => {
+  const initializedMock = jest.fn();
+  const pendingMock = jest.fn();
+  const successMock = jest.fn();
+  const failureMock = jest.fn();
+  const _Mock = jest.fn();
+
+  new Initialized().match({
+    _: _Mock
+  });
+  new Initialized().match({
+    Initialized: initializedMock,
+    _: _Mock
+  });
+  new Initialized().match({
+    Initialized: initializedMock,
+    Pending: pendingMock,
+    Success: successMock,
+    Failure: failureMock,
+    _: _Mock
+  });
+  expect(initializedMock).toHaveBeenCalledTimes(2);
+  expect(pendingMock).not.toHaveBeenCalled();
+  expect(successMock).not.toHaveBeenCalled();
+  expect(failureMock).not.toHaveBeenCalled();
+  expect(_Mock).toHaveBeenCalledTimes(1);
+});
+
+test("match _ with Pending", () => {
+  const initializedMock = jest.fn();
+  const pendingMock = jest.fn();
+  const successMock = jest.fn();
+  const failureMock = jest.fn();
+  const _Mock = jest.fn();
+
+  new Pending().match({
+    _: _Mock
+  });
+  new Pending().match({
+    Pending: pendingMock,
+    _: _Mock
+  });
+  new Pending().match({
+    Initialized: initializedMock,
+    Pending: pendingMock,
+    Success: successMock,
+    Failure: failureMock,
+    _: _Mock
+  });
+  expect(initializedMock).not.toHaveBeenCalled();
+  expect(pendingMock).toHaveBeenCalledTimes(2);
+  expect(successMock).not.toHaveBeenCalled();
+  expect(failureMock).not.toHaveBeenCalled();
+  expect(_Mock).toHaveBeenCalledTimes(1);
+});
+
+test("match _ with Success", () => {
+  const initializedMock = jest.fn();
+  const pendingMock = jest.fn();
+  const successMock = jest.fn();
+  const failureMock = jest.fn();
+  const _Mock = jest.fn();
+
+  const data = { apple: "sauce" };
+  new Success(data).match({
+    _: _Mock
+  });
+  new Success(data).match({
+    Success: successMock,
+    _: _Mock
+  });
+  new Success(data).match({
+    Initialized: initializedMock,
+    Pending: pendingMock,
+    Success: successMock,
+    Failure: failureMock,
+    _: _Mock
+  });
+  expect(initializedMock).not.toHaveBeenCalled();
+  expect(pendingMock).not.toHaveBeenCalled();
+  expect(successMock).toHaveBeenCalledTimes(2);
+  expect(successMock).toHaveBeenNthCalledWith(1, data);
+  expect(successMock).toHaveBeenNthCalledWith(2, data);
+  expect(failureMock).not.toHaveBeenCalled();
+  expect(_Mock).toHaveBeenCalledTimes(1);
+});
+
+test("match _ with Failure", () => {
+  const initializedMock = jest.fn();
+  const pendingMock = jest.fn();
+  const successMock = jest.fn();
+  const failureMock = jest.fn();
+  const _Mock = jest.fn();
+
+  const error = 500;
+  new Failure(error).match({
+    _: _Mock
+  });
+  new Failure(error).match({
+    Failure: failureMock,
+    _: _Mock
+  });
+  new Failure(error).match({
+    Initialized: initializedMock,
+    Pending: pendingMock,
+    Success: successMock,
+    Failure: failureMock,
+    _: _Mock
+  });
+  expect(initializedMock).not.toHaveBeenCalled();
+  expect(pendingMock).not.toHaveBeenCalled();
+  expect(successMock).not.toHaveBeenCalled();
+  expect(failureMock).toHaveBeenCalledTimes(2);
+  expect(failureMock).toHaveBeenNthCalledWith(1, error);
+  expect(failureMock).toHaveBeenNthCalledWith(2, error);
+  expect(_Mock).toHaveBeenCalledTimes(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 export type RemoteData<E, D> = Initialized | Pending | Failure<E> | Success<D>;
 
 export enum Kinds {
-  Initialized = "Initialized",
-  Pending = "Pending",
-  Failure = "Failure",
-  Success = "Success",
-  _ = "_"
+  Initialized = 'Initialized',
+  Pending = 'Pending',
+  Failure = 'Failure',
+  Success = 'Success',
+  _ = '_'
 }
 
 type CompleteDataMatcher<T, E, D> = {
@@ -33,6 +33,7 @@ function isComplete<T, E, D>(
 ): matcher is CompleteDataMatcher<T, E, D> {
   return (matcher as CompleteDataMatcher<T, E, D>)[Kinds.Failure] !== undefined;
 }
+
 export class Initialized {
   readonly kind = Kinds.Initialized;
   match<T, E, D>(matcher: Matcher<T, E, D>): T {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,66 @@
 export type RemoteData<E, D> = Initialized | Pending | Failure<E> | Success<D>;
 
 export enum Kinds {
-  Initialized = 'Initialized',
-  Pending = 'Pending',
-  Failure = 'Failure',
-  Success = 'Success',
+  Initialized = "Initialized",
+  Pending = "Pending",
+  Failure = "Failure",
+  Success = "Success",
+  _ = "_"
 }
 
+type CompleteDataMatcher<T, E, D> = {
+  [Kinds.Initialized]: () => T;
+  [Kinds.Pending]: () => T;
+  [Kinds.Failure]: (error: E) => T;
+  [Kinds.Success]: (data: D) => T;
+};
+
+type PartialDataMatcher<T, E, D> = {
+  [Kinds.Initialized]?: () => T;
+  [Kinds.Pending]?: () => T;
+  [Kinds.Failure]?: (error: E) => T;
+  [Kinds.Success]?: (data: D) => T;
+  [Kinds._]: () => T;
+};
+
+type Matcher<T, E, D> =
+  | CompleteDataMatcher<T, E, D>
+  | PartialDataMatcher<T, E, D>;
+
+// A type guard to let typescript realize that either it's a complete data mate
+function isComplete<T, E, D>(
+  matcher: Matcher<T, E, D>
+): matcher is CompleteDataMatcher<T, E, D> {
+  return (matcher as CompleteDataMatcher<T, E, D>)[Kinds.Failure] !== undefined;
+}
 export class Initialized {
   readonly kind = Kinds.Initialized;
+  match<T, E, D>(matcher: Matcher<T, E, D>): T {
+    if (isComplete(matcher)) {
+      let specific = matcher[this.kind];
+      return specific();
+    }
+    let specific = matcher[this.kind];
+    if (specific !== undefined) {
+      return specific();
+    }
+    return matcher[Kinds._]();
+  }
 }
 
 export class Pending {
   readonly kind = Kinds.Pending;
+  match<T, E, D>(matcher: Matcher<T, E, D>): T {
+    if (isComplete(matcher)) {
+      let specific = matcher[this.kind];
+      return specific();
+    }
+    let specific = matcher[this.kind];
+    if (specific !== undefined) {
+      return specific();
+    }
+    return matcher[Kinds._]();
+  }
 }
 
 export class Failure<E> {
@@ -22,6 +70,17 @@ export class Failure<E> {
     if (error === null || error === undefined) {
       throw new TypeError('Parameter "error" is required');
     }
+  }
+  match<T, D>(matcher: Matcher<T, E, D>): T {
+    if (isComplete(matcher)) {
+      let specific = matcher[this.kind];
+      return specific(this.error);
+    }
+    let specific = matcher[this.kind];
+    if (specific !== undefined) {
+      return specific(this.error);
+    }
+    return matcher[Kinds._]();
   }
 }
 
@@ -33,13 +92,24 @@ export class Success<D> {
       throw new TypeError('Parameter "data" is required');
     }
   }
+  match<T, E>(matcher: Matcher<T, E, D>): T {
+    if (isComplete(matcher)) {
+      let specific = matcher[this.kind];
+      return specific(this.data);
+    }
+    let specific = matcher[this.kind];
+    if (specific !== undefined) {
+      return specific(this.data);
+    }
+    return matcher[Kinds._]();
+  }
 }
 
 export function fold<T, E, D>(
   initialized: () => T,
   pending: () => T,
   failure: (error: E) => T,
-  success: (data: D) => T,
+  success: (data: D) => T
 ): (state: RemoteData<E, D>) => T {
   return (state: RemoteData<E, D>) => {
     switch (state.kind) {
@@ -54,7 +124,7 @@ export function fold<T, E, D>(
       default:
         throw new NeverError(state);
     }
-  }
+  };
 }
 
 class NeverError extends Error {


### PR DESCRIPTION
Based on this blog post: https://blog.parametricstudios.com/posts/pattern-matching-custom-data-types/  I added a match like interface that can be used instead of fold.  

I'm not 100% happy with the resulting code, I've repeated things too often, but this compiles with typescript and the new tests pass.  If you like the idea of adding it, then I can do some more work to clean it up and try and make it more simple to use. 